### PR TITLE
Stacked generator Dependency Update

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,10 +545,10 @@ packages:
     dependency: "direct dev"
     description:
       name: stacked_generator
-      sha256: "8b04310f3daf03e5de15ae8f768c5598157f2b84c8388cbb71a4ee59f6e93a61"
+      sha256: b47fcc04b016d4cb1c35c1b2622fae5cfc5a77b587a374dfccdc27968208edf4
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5"
+    version: "0.9.3"
   stacked_services:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
 
   # code generators
   build_runner: ^2.3.3
-  stacked_generator: ^0.8.3
+  stacked_generator: ^0.9.3
   envied_generator: ^0.3.0
 
 flutter:


### PR DESCRIPTION
- `stacked_generator` dependency updated to `0.9.3`.

A new `stacked_generator` update was released about seven hours ago. Since it doesn't have any conflicts, it has been updated.