### PR TITLE
Startup Navigation

### DIFF
--- a/lib/ui/views/startup/startup_viewmodel.dart
+++ b/lib/ui/views/startup/startup_viewmodel.dart
@@ -21,10 +21,10 @@ class StartupViewModel extends BaseViewModel {
   }
 
   void gotoWrapper() {
-    _navigationService.navigateToWrapperView();
+    _navigationService.clearStackAndShow(Routes.wrapperView);
   }
 
   void gotoAuth() {
-    _navigationService.navigateToAuthenticationView();
+    _navigationService.clearStackAndShow(Routes.authenticationView);
   }
 }


### PR DESCRIPTION
Startup navigation change from utilizing the `navigateTo` into `clearStackAndShow` so the user wont go back to the startup view accidentally or on purpose.